### PR TITLE
fix: 修复在 `.ts` 文件中使用 `triple-slash-reference` 导入类型的错误

### DIFF
--- a/src/functions/openApi2Data.ts
+++ b/src/functions/openApi2Data.ts
@@ -70,6 +70,7 @@ export interface TemplateData extends Omit<OpenAPIV3_1.Document, ''> {
   global: string;
   alovaVersion: AlovaVersion;
   commentText: string;
+  useImportType: boolean;
 }
 const remove$ref = (
   originObj: OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject,
@@ -343,7 +344,8 @@ export default async function openApi2Data(
     commentText: '',
     schemas: [],
     alovaVersion: 'v2',
-    global: config.global ?? 'Apis'
+    global: config.global ?? 'Apis',
+    useImportType: config?.useImportType ?? false
   };
   const schemasMap = new Map<string, string>();
   const searchMap = new Map<string, string>();

--- a/templates/apiDefinitions.handlebars
+++ b/templates/apiDefinitions.handlebars
@@ -1,4 +1,4 @@
-import './globals.d.ts'
+{{#if useImportType}}import './globals.d.ts'{{else}}/// <reference types='./globals.d.ts' />{{/if}}
 {{{commentText}}}
 {{#if (eq moduleType "ESModule")}}export default{{else if (eq moduleType "commonJs")}}module.exports ={{/if}} {
 {{#pathsArr}}

--- a/templates/apiDefinitions.handlebars
+++ b/templates/apiDefinitions.handlebars
@@ -1,4 +1,4 @@
-///<reference path='./globals.d.ts' />
+import './globals.d.ts'
 {{{commentText}}}
 {{#if (eq moduleType "ESModule")}}export default{{else if (eq moduleType "commonJs")}}module.exports ={{/if}} {
 {{#pathsArr}}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -45,6 +45,9 @@ declare type GeneratorConfig = {
   version: Number;
   // 多项目使用global字段
   global?: string;
+  // 是否使用import来导入类型，默认false
+  // 开启此选项后，生成的apiDefinitions.ts文件将使用import语法来导入类型，而不是/// <reference types="..." />
+  useImportType: boolean;
   // （具体看下面）过滤或转换生成的api接口函数，返回一个新的apiDescriptor来生成api调用函数
   // 未指定此函数时则不转换apiDescripor对象
   // apiDescriptor的格式与openapi文件的接口对象格式相同


### PR DESCRIPTION
在 `.ts` 文件中使用 `triple-slash-reference` 导入类型会报下图的错误，应该使用 `import` 来导入类型
```
  x typescript-eslint(triple-slash-reference): Do not use a triple slash reference for './globals.d.ts', use `import` style instead.
   ,-[api\upms\apiDefinitions.ts:1:1]
 1 | ///<reference path='./globals.d.ts' />
   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 2 | /* tslint:disable */
   `----
  help: Use of triple-slash reference type directives is generally discouraged in favor of ECMAScript Module imports.
```