### PR TITLE
fix: 修复schema.type为string时没有兼容format为binary的问题

### DIFF
--- a/src/helper/schema2type.ts
+++ b/src/helper/schema2type.ts
@@ -117,7 +117,13 @@ function parseSchema(
       result = parseArray(schema, openApi, config);
       break;
     case 'string':
-      result = 'string';
+      // 根据 https://swagger.io/docs/specification/data-models/data-types/#string
+      // 针对binary，将类型更改为Blob，其余所有format值均可视为string
+      if (schema.format === 'binary') {
+        result = 'Blob';
+      } else {
+        result = 'string';
+      }
       break;
     case 'number':
     case 'integer':


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/95e22f18-0339-4895-8e91-8295671ce225)
使用的文件为 https://petstore.swagger.io/v2/swagger.json
