### PR TITLE
fix(helper/typestr): 修复获取默认值时产生的语法不正确

### DIFF
--- a/src/helper/typeStr.ts
+++ b/src/helper/typeStr.ts
@@ -10,7 +10,7 @@ function removeComments(content: string) {
 const LEFT_BRACKET = ['(', '<', '{', '['];
 const RIGHT_BRACKET = [')', '>', '}', ']'];
 function parseTypeBody(typeBody: string) {
-  const properties = [];
+  let properties = [];
   let bracketCount = 0;
   let currentProperty = '';
 
@@ -30,6 +30,16 @@ function parseTypeBody(typeBody: string) {
   if (currentProperty.trim()) {
     properties.push(currentProperty.trim());
   }
+  let curId = 0;
+  properties.forEach((p, idx, arr) => {
+    if (/^.+:.*$/.test(p)) {
+      curId = idx;
+    } else {
+      arr[curId] += p;
+      arr[idx] = '';
+    }
+  });
+  properties = properties.filter(p => !!p);
   const parsedProperties = properties
     .map(prop => {
       const [keyOrigin, ...valueOrigin] = prop.split(':');
@@ -75,7 +85,9 @@ function splitTypes(typeStr: string, c: '&' | '|'): string[] {
     }
 
     if (char === c && bracketCount === 0) {
-      result.push(currentType.trim());
+      if (currentType) {
+        result.push(currentType.trim());
+      }
       currentType = '';
     } else {
       currentType += char;


### PR DESCRIPTION
![b97204efe1edf4cb23120b47fdb5e67](https://github.com/user-attachments/assets/118da91e-f97c-4d71-9a13-71e0f377934b)
处理枚举换行时的情况