### PR TITLE
fix(wormhole): validate API responses to prevent empty object generation

### DIFF
--- a/.changeset/slow-games-call.md
+++ b/.changeset/slow-games-call.md
@@ -1,0 +1,5 @@
+---
+'@alova/wormhole': patch
+---
+
+Fixes issue where invalid responses like {"code": -1, "msg": "URL does not exist"} would generate empty apiDefinitions and global objects.


### PR DESCRIPTION
- Add validation for error response format (e.g., {"code": -1, "msg": "URL does not exist"})
- Verify OpenAPI/Swagger document structure before processing
- Handle both platform-type URLs and direct file URLs
- Improve error messages for invalid API docs
- Remove redundant validation checks after consolidation

Fixes issue where invalid responses like {"code": -1, "msg": "URL does not exist"} would generate empty apiDefinitions and global objects.