### PR TITLE
fix(wormhole): add missing HTTP methods to supportedApiMethods

### DIFF
--- a/.changeset/purple-laws-hang.md
+++ b/.changeset/purple-laws-hang.md
@@ -1,0 +1,6 @@
+---
+"@alova/wormhole": patch
+"alova-vscode-extension": patch
+---
+
+Add missing HTTP methods: PATCH, HEAD, OPTIONS

--- a/packages/vscode-extension/src/components/ApiMethod.vue
+++ b/packages/vscode-extension/src/components/ApiMethod.vue
@@ -13,6 +13,8 @@ const TagMap: Record<MethodType, TagProps['type']> = {
   DELETE: 'error',
   PATCH: 'default',
   TRACE: 'info',
+  HEAD: 'default',
+  OPTIONS: 'default',
 }
 </script>
 

--- a/packages/vscode-extension/src/types.ts
+++ b/packages/vscode-extension/src/types.ts
@@ -7,4 +7,4 @@ export interface ApiProject {
 }
 
 export type { Api, ApiDoc, HandlersType }
-export type MethodType = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'TRACE'
+export type MethodType = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'TRACE' | 'HEAD' | 'OPTIONS'

--- a/packages/wormhole/src/helper/document/index.ts
+++ b/packages/wormhole/src/helper/document/index.ts
@@ -1,7 +1,19 @@
 import type { ApiMethod, OpenAPIDocument } from '@/type'
 import { HttpMethod } from '@/type'
 
-export const supportedApiMethods: HttpMethod[] = [HttpMethod.GET, HttpMethod.PUT, HttpMethod.POST, HttpMethod.DELETE]
+/**
+ * 支持的API方法列表
+ * @see https://github.com/alovajs/alova/blob/main/packages/alova/typings/index.d.ts#L640
+ */
+export const supportedApiMethods: HttpMethod[] = [
+  HttpMethod.GET,
+  HttpMethod.PUT,
+  HttpMethod.POST,
+  HttpMethod.DELETE,
+  HttpMethod.PATCH,
+  HttpMethod.HEAD,
+  HttpMethod.OPTIONS,
+]
 
 export class OpenApiHelper {
   private document: OpenAPIDocument


### PR DESCRIPTION
- Add missing HTTP methods: PATCH, HEAD, OPTIONS
- Convert single-line comment to JSDoc format with Chinese description
- Improve code formatting with multi-line array structure
- Add reference link to alova typings for consistency

close #98 