### PR TITLE
fix(worma): guard getParserSchemaType against undefined schema

### DIFF
--- a/packages/worma/src/core/loader/astLoader/parsers/utils.ts
+++ b/packages/worma/src/core/loader/astLoader/parsers/utils.ts
@@ -48,6 +48,9 @@ export function parse(schema: MaybeSchemaObject, options: {
   return null
 }
 export function getParserSchemaType(schema: MaybeSchemaObject): ParserSchemaType {
+  if (!schema) {
+    return 'null'
+  }
   if (isReferenceObject(schema)) {
     return 'reference'
   }

--- a/packages/worma/test/parsers/utils.spec.ts
+++ b/packages/worma/test/parsers/utils.spec.ts
@@ -1,0 +1,18 @@
+import type { MaybeSchemaObject, SchemaObject } from '@/type'
+import { getParserSchemaType } from '@/core/loader/astLoader/parsers/utils'
+
+describe('getParserSchemaType', () => {
+  it('should resolve a primitive schema to its type', () => {
+    const schema: SchemaObject = { type: 'string' }
+    expect(getParserSchemaType(schema)).toBe('string')
+  })
+
+  it('should resolve a $ref schema to reference', () => {
+    expect(getParserSchemaType({ $ref: '#/components/schemas/Foo' })).toBe('reference')
+  })
+
+  it('should return null for an array whose items are undefined', () => {
+    // An `array` schema without `items` yields `undefined` when its item is parsed.
+    expect(getParserSchemaType(undefined as unknown as MaybeSchemaObject)).toBe('null')
+  })
+})


### PR DESCRIPTION
Closes #830.

An `array` schema with no `items` makes `arrayTypeParser` call `ctx.next(undefined, ...)`, so `getParserSchemaType` receives `undefined` and throws `Cannot read properties of undefined (reading 'type')` at `parsers/utils.ts` when it reaches `schema.type`.

Return `'null'` early when the schema is nullish, matching the existing fallback for typeless schemas, so `alova gen` no longer crashes on such documents. Added a unit test in `test/parsers/utils.spec.ts` covering the undefined case.