### PR TITLE
fix(worma): handle array schema without items in ast parser

### DIFF
--- a/packages/worma/src/core/loader/astLoader/parsers/array.ts
+++ b/packages/worma/src/core/loader/astLoader/parsers/array.ts
@@ -6,7 +6,7 @@ import { initAST } from './utils'
 
 export function arrayTypeParser(schema: ArraySchemaObject, ctx: ParserCtx) {
   ctx.pathKey = '[]'
-  const itemsAst = ctx.next(schema.items, ctx.options)
+  const itemsAst = ctx.next(schema.items ?? {}, ctx.options)
   const result: TArray = {
     ...initAST(schema, ctx),
     type: ASTType.ARRAY,

--- a/packages/worma/test/parsers/array.spec.ts
+++ b/packages/worma/test/parsers/array.spec.ts
@@ -274,5 +274,26 @@ describe('array Type Parser', () => {
       expect(result.deepComment).toContain('[items] start')
       expect(result.deepComment).toContain('[items] end')
     })
+
+    it('should handle array without items', () => {
+      const schema = {
+        type: 'array',
+        description: 'Array without items',
+      } as ArraySchemaObject
+
+      const mockItemAST: AST = {
+        type: ASTType.ANY,
+        keyName: '',
+      }
+
+      const ctx = createMockCtx('itemlessArray')
+      ctx.next = vi.fn().mockReturnValue(mockItemAST)
+
+      const result = arrayTypeParser(schema, ctx)
+
+      expect(result.type).toBe(ASTType.ARRAY)
+      expect(result.params).toBe(mockItemAST)
+      expect(ctx.next).toHaveBeenCalledWith({}, ctx.options)
+    })
   })
 })


### PR DESCRIPTION
When an OpenAPI array schema omits `items`, `arrayTypeParser` passes `undefined` into `ctx.next`, which reaches `getParserSchemaType` and throws `Cannot read properties of undefined (reading 'type')` during `worma gen`. An array without `items` is valid (items are unconstrained), so this crashes codegen on otherwise valid documents.

This defaults the missing `items` to an empty schema `{}`, matching how `objectTypeParser` already falls back with `schema.properties || {}`. Added a regression test in `test/parsers/array.spec.ts` for the itemless-array case.

Fixes #830
