### PR TITLE
fix(worma): isolate schema workers per generator

### DIFF
--- a/.changeset/fix-generator-worker-isolation.md
+++ b/.changeset/fix-generator-worker-isolation.md
@@ -1,0 +1,5 @@
+---
+"wormajs": patch
+---
+
+Isolate schema worker pools by generator output so concurrent OpenAPI documents cannot resolve references against another generator's document.

--- a/packages/worma/src/core/parser/templateParser/index.ts
+++ b/packages/worma/src/core/parser/templateParser/index.ts
@@ -128,9 +128,11 @@ export class TemplateParser implements Parser<OpenAPIDocument, TemplateData, Tem
         const { existsSync: fex } = await import('node:fs')
         const workerScript = fex(jsWp) ? jsWp : tsWp
 
-        // P2: Reuse worker pool via PoolManager singleton — avoids create/destroy overhead across repeated generate() calls
+        // Reuse workers only within the same generator output. The workerData document is immutable after spawn,
+        // so generators in the same project must not share a pool.
+        const outputDir = path.resolve(this.options.projectPath, this.options.generatorConfig.output!)
         const pool = PoolManager.getInstance().get<{ key: string, schema: SchemaObject }, { key: string, result: string }>({
-          key: `schemaWorker_${this.options.projectPath}`,
+          key: `schemaWorker_${outputDir}`,
           workerScript,
           sharedContext: {
             document: this.document,

--- a/packages/worma/test/templateParserWorkerPool.spec.ts
+++ b/packages/worma/test/templateParserWorkerPool.spec.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  */
 
 let capturedSharedContext: any
+let capturedSharedContexts: any[] = []
 let workerSpawned = false
 
 vi.mock('@/core/WorkerPool', async (importActual) => {
@@ -25,6 +26,7 @@ vi.mock('@/core/WorkerPool', async (importActual) => {
     WorkerPool: class FakeWorkerPool<Task, Result> {
       constructor(opts: any) {
         capturedSharedContext = opts.sharedContext
+        capturedSharedContexts.push(opts.sharedContext)
         workerSpawned = true
       }
 
@@ -42,7 +44,7 @@ vi.mock('node:fs')
 vi.mock('node:fs/promises')
 
 /** Programmatically generate an OpenAPI 3.0 document with more than 200 endpoints to trigger the worker pool branch */
-function makeBigSpec(endpointCount: number) {
+function makeBigSpec(endpointCount: number, schemaName = 'Item', title = 'Big Spec') {
   const paths: Record<string, any> = {}
   for (let i = 0; i < endpointCount; i++) {
     paths[`/api/item${i}`] = {
@@ -52,7 +54,7 @@ function makeBigSpec(endpointCount: number) {
         responses: {
           200: {
             description: 'ok',
-            content: { 'application/json': { schema: { $ref: '#/components/schemas/Item' } } },
+            content: { 'application/json': { schema: { $ref: `#/components/schemas/${schemaName}` } } },
           },
         },
       },
@@ -60,12 +62,12 @@ function makeBigSpec(endpointCount: number) {
   }
   return {
     openapi: '3.0.0',
-    info: { title: 'Big Spec', version: '1.0.0' },
+    info: { title, version: '1.0.0' },
     servers: [{ url: 'https://example.com' }],
     paths,
     components: {
       schemas: {
-        Item: {
+        [schemaName]: {
           type: 'object',
           properties: { id: { type: 'integer', format: 'int64' }, name: { type: 'string' } },
         },
@@ -93,6 +95,7 @@ describe('templateParser worker pool sharedContext (regression: could not be clo
     vol.reset()
     vol.mkdirSync('/project', { recursive: true })
     capturedSharedContext = undefined
+    capturedSharedContexts = []
     workerSpawned = false
   })
 
@@ -137,6 +140,45 @@ describe('templateParser worker pool sharedContext (regression: could not be clo
     expect(config.defaultRequire).toBe(false)
     expect(config.externalTypes).toEqual(['File'])
     expect(config.plugins).toBeUndefined()
+  }, 30000)
+
+  it('isolates worker contexts for generators with different outputs', async () => {
+    const mallSpec = makeBigSpec(25, 'MallActivity', 'Mall API')
+    const adminSpec = makeBigSpec(25, 'AdminUser', 'Admin API')
+    const mallSpecPath = '/project/mall.json'
+    const adminSpecPath = '/project/admin.json'
+    vol.writeFileSync(mallSpecPath, JSON.stringify(mallSpec))
+    vol.writeFileSync(adminSpecPath, JSON.stringify(adminSpec))
+
+    const { generate } = await import('@/index')
+    const { alova } = await import('@/plugins')
+
+    await generate({
+      generator: [
+        {
+          input: mallSpecPath,
+          output: '/project/api/mall',
+          type: 'ts',
+          plugins: [alova()],
+        },
+        {
+          input: adminSpecPath,
+          output: '/project/api/admin',
+          type: 'ts',
+          plugins: [alova()],
+        },
+      ],
+    }, { force: true, projectPath: '/project' })
+
+    expect(capturedSharedContexts).toHaveLength(2)
+    expect(capturedSharedContexts.map(context => context.document.info.title).sort()).toEqual([
+      'Admin API',
+      'Mall API',
+    ])
+    expect(capturedSharedContexts.map(context => Object.keys(context.document.components.schemas)[0]).sort()).toEqual([
+      'AdminUser',
+      'MallActivity',
+    ])
   }, 30000)
 
   it('does not spawn worker pool when apiCount <= 200', async () => {

--- a/plans/worma新特性提案.md
+++ b/plans/worma新特性提案.md
@@ -1503,4 +1503,13 @@ worma.config.js
 ### 缓存产出物
 
 生成的缓存文件从 `.alova-cache/` 目录改为 `.worma-cache/`，建议更新 `.gitignore`（若之前有配置）。
+
+## 多 Generator 的 Schema Worker 隔离
+
+同一次 `generate()` 可以并行处理多个 generator。Schema worker 会在创建时通过 `workerData` 固定持有当前 generator 的 OpenAPI 文档、类型映射和生成配置，因此 worker 池的缓存身份必须包含 generator 的输出目录，不能只使用项目目录。
+
+- 同一 `projectPath` 下，不同 `output` 的 generator 必须创建独立的 schema worker 池。
+- worker 池 key 使用规范化后的绝对输出路径，避免 mall、admin 等多个 OpenAPI 文档复用错误的文档上下文。
+- 保留不同 generator 的并行生成能力，不通过串行化或关闭 worker 池规避上下文污染。
+- 增加双 generator 回归测试，确保两个 worker 分别持有各自的 OpenAPI 文档。
 ````

--- a/plans/worma规格说明.md
+++ b/plans/worma规格说明.md
@@ -792,3 +792,24 @@ workspace 模式下若 `resolveWorkspaces()` 返回空数组，打印错误信�
 - 提案：`./worma@2新特性提案.md`
 - 现有实现：`packages/worma/src/{config,readConfig,generate}.ts`、`helper/config/{ConfigHelper,GeneratorHelper,type,zType}.ts`、`helper/template/index.ts`、`core/parser/templateParser/index.ts`、`template/presets/*`
 - VSCode 扩展集成点：`packages/vscode-extension/ext/functions/getWorma.ts`、`ext/views/api-server.ts`
+
+---
+
+## 16. 多 Generator Schema Worker 隔离 ✅
+
+### 16.1 问题
+
+多个 generator 在同一项目中并行运行时，schema worker 池不能仅以 `projectPath` 作为缓存键。worker 的 `sharedContext.document` 在创建时固定；若不同 generator 复用同一 worker，后续 generator 的 `$ref` 会在错误的 OpenAPI 文档中解析。
+
+### 16.2 规格
+
+- schema worker 池 key 必须包含 `path.resolve(projectPath, generator.output)`。
+- 相同项目、不同输出目录的 generator 必须获得不同的 worker 实例和 `sharedContext`。
+- 保持 `generate()` 的并行执行方式不变。
+- 回归测试必须构造两份包含不同 schema 的 OpenAPI 文档，并验证两个 worker 上下文互不复用。
+
+### 16.3 验收状态
+
+- [x] worker 池按 generator 输出目录隔离。
+- [x] 双 generator 回归测试通过。
+- [x] worma 单元测试与类型检查通过。


### PR DESCRIPTION
## Summary

- isolate schema worker pools by each generator output directory
- prevent concurrent OpenAPI generators from resolving refs against another document
- add a two-generator regression test using distinct MallActivity and AdminUser schemas
- document the isolation contract and add a patch changeset

## Root cause

Schema workers were cached only by projectPath even though workerData permanently captures one OpenAPI document. Multiple generators in the same project could therefore reuse the wrong document context, causing timing-dependent missing-ref failures or false success when processBatch calls overlapped.

## Validation

- pnpm --filter wormajs test: 63 files passed, 777 tests passed, 6 skipped
- pnpm --filter wormajs build
- ESLint on the changed source and regression test